### PR TITLE
Show leader order when not displaying table of all actions. Closes #18.

### DIFF
--- a/avalon/avalon_game/templates/in_game.html
+++ b/avalon/avalon_game/templates/in_game.html
@@ -59,7 +59,22 @@
 
 {% block history %}
 {{ debug }}
-{% if display_history %}
+{% if not display_history %}
+<table id="player_order">
+    <thead>
+        <tr>
+            <th>Leader order</th>
+        </tr>
+    </thead>
+    <tbody>
+        {% for p in players %}
+        <tr>
+            <td>{{ p.name }}</td>
+        </tr>
+        {% endfor %}
+    </tbody>
+</table>
+{% else %}
 <table id="history">
   <thead>
     <tr>


### PR DESCRIPTION
Might want to decorate this list further with current player and current leader.